### PR TITLE
OSX support for ptp200bt

### DIFF
--- a/lib/drivers/brother_ptp300bt.js
+++ b/lib/drivers/brother_ptp300bt.js
@@ -37,8 +37,20 @@ module.exports.description = 'Brother PT-P300BT';
 
 
 function get_serial() {
+  // Linux check
   // TODO: check that it is a recognized printer
-  return fs.existsSync('/dev/rfcomm0') ? '/dev/rfcomm0' : null;
+  if (fs.existsSync('/dev/rfcomm0')){
+    return '/dev/rfcomm0';
+  }
+
+  // OSX check
+  var devices = fs.readdirSync('/dev/').filter(fn => fn.startsWith('tty.PT-P300BT'));
+  if (devices.length > 0){
+    // First found device is selected
+    return devices[0];
+  }
+
+  return null;
 }
 
 
@@ -113,7 +125,7 @@ module.exports.print = async (image/*, args*/) => {
     }
 
     send([ 0x1B, 0x69, 0x53 ]);
-    fs.readSync(file, buf, 32);
+    fs.readSync(file, buf, 0, 32);
     return buf.slice(0, 32);
   };
 


### PR DESCRIPTION
Thanks for the great tool :)

I had to adapt it a bit for my personal usage as a macos user and I'm sharing those changes with you.
I've done something simple that gets the first printer available, it's not perfect but that's useful nonetheless.

I had to also fix the call to fs.readSync, it seems like it's API changed at some point.

I'm not a JS dev, don't hesitate to propose better ways of doing this.