### PR TITLE
Fix incomplete device path on OSX

### DIFF
--- a/lib/drivers/brother_ptp300bt.js
+++ b/lib/drivers/brother_ptp300bt.js
@@ -47,7 +47,7 @@ function get_serial() {
   var devices = fs.readdirSync('/dev/').filter(fn => fn.startsWith('tty.PT-P300BT'));
   if (devices.length > 0){
     // First found device is selected
-    return devices[0];
+    return '/dev/' + devices[0];
   }
 
   return null;


### PR DESCRIPTION
I assumed the filtered content contained the /dev/ path but that wasn't the case.

This is now fixed